### PR TITLE
Update do wersji 1.3.2 wtyczki

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -10,7 +10,7 @@
 name=Usługa Lokalizacji Działek Katastralnych
 qgisMinimumVersion=3.0
 description=Wtyczka pozwala na pobieranie geometrii granic działek katastralnych, obrębów, gmin, powiatów i województw. ENG: The plugin made for dowloading parcells geometry from The Central Office of Geodesy and Cartography of Poland "ULDK API".
-version=1.3.1
+version=1.3.2
 author=Envirosolutions Sp. z o.o.
 email=office@envirosolutions.pl
 
@@ -24,8 +24,10 @@ repository=https://github.com/envirosolutionspl/uldk
 
 # Uncomment the following line and add your changelog:
 changelog=
-  Wersja 1.3.1
-  * Usunięcie przybliżania do działek po pobraniu przez kliknięcie z mapy
+  Wersja 1.3.2
+  * Zmiana znaku formatowania danych
+#Wersja 1.3.1
+#* Usunięcie przybliżania do działek po pobraniu przez kliknięcie z mapy
 #Wersja 1.3.0
 #* Obsługa błędów w przypadku niedziałającego serwisu
 #* Poprawa funkcjonowania pobierania elementów z usługi ULDK

--- a/uldk_gugik.py
+++ b/uldk_gugik.py
@@ -36,7 +36,7 @@ import os.path
 from . import utils, uldk_api, uldk_xy, uldk_parcel
 
 """Wersja wtyczki"""
-plugin_version = '1.3.1'
+plugin_version = '1.3.2'
 plugin_name = 'ULDK GUGiK'
 
 class UldkGugik:

--- a/uldk_gugik.py
+++ b/uldk_gugik.py
@@ -1035,6 +1035,9 @@ class UldkGugik:
         if "," in x or "," in y:
             x = float(x.replace(",", "."))
             y = float(y.replace(",", "."))
+        else:
+            x = float(x)
+            y = float(y)
 
         requestPoint = QgsPoint(x, y)
         QgsMessageLog.logMessage(str(srid), 'ULDK')

--- a/uldk_gugik_dialog_base.ui
+++ b/uldk_gugik_dialog_base.ui
@@ -14,7 +14,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>ULDK GUGiK 1.3.1</string>
+   <string>ULDK GUGiK 1.3.2</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -242,7 +242,7 @@
        <string>Wprowadź współrzędne</string>
       </property>
      </widget>
-     <widget class="QgsProjectionSelectionWidget" name="projectionWidget" native="true">
+     <widget class="QgsProjectionSelectionWidget" name="projectionWidget">
       <property name="geometry">
        <rect>
         <x>10</x>
@@ -795,7 +795,7 @@
     <item>
      <widget class="QLabel" name="lbl_pluginVersion">
       <property name="text">
-       <string>ULDK GUGiK 1.3.1</string>
+       <string>ULDK GUGiK 1.3.2</string>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
Dodano uwzględnienie wyjątku, kiedy współrzędne w okreslonych wersjach wtyczki są zapisane jako string, ale rozdzielone innym znakiem niż przecinek.