### PR TITLE
Usunięcie na sztywno zdefiniowanej kolorystyki tekstu comboboxa

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -103,7 +103,7 @@ RES_COUNTY_BY_ID = ["geom_wkt", "teryt", "county", "voivodeship"]
 RES_VOIVODESHIP_BY_ID = ["geom_wkt", "teryt", "voivodeship"]
 
 COMBOBOX_STYLES = {
-    "visible": "QComboBox { color: black }",
+    "visible": "",
     "hidden": "QComboBox { color: transparent }"
 }
 


### PR DESCRIPTION
<img width="829" height="538" alt="image" src="https://github.com/user-attachments/assets/8285826f-b83e-4c70-88db-fecb9219fc6d" />
